### PR TITLE
Fix: Check the length of errs instead of checking if slackErrorMsg is…

### DIFF
--- a/main.go
+++ b/main.go
@@ -139,9 +139,8 @@ func main() {
 	}
 
 	errs := getFileInfo(basePath, outputFiles)
-	slackErrorMsg := formatErrors(errs)
-
-	if slackErrorMsg != "" {
+	if len(errs) > 0 {
+		slackErrorMsg := formatErrors(errs)
 		payload, err := formatSlackPayload(slackErrorMsg)
 		if err != nil {
 			log.Fatal(err.Error())


### PR DESCRIPTION
… an empty string